### PR TITLE
feat(crypto/string): reinstate crypto commands and refactor string subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ The specific details of each are:
 
   ```bash
   anbu string 23               # generate 23 (100 if not specified) random alphanumeric chars
-  anbu string seq 29           # prints "abcdefghijklmnopqrstuvxyz" until desired length
+  anbu string seq 29           # prints "abcdefghijklmnopqrstuvwxyz" until desired length
   anbu string rep 23 str2rep   # prints "str2repstr2rep...23 times"
 
   anbu string uuid     # generates a uuid
-  anbu string ruid 16  # generates a short uuid of length b/w 1-32
+  anbu string ruid 16  # generates a short uuid of length b/w 1-30
   anbu string suid     # generates a short uuid of length 18
 
   anbu string password           # generate a 12-character complex password

--- a/cmd/crypto-cmd/file-crypto.go
+++ b/cmd/crypto-cmd/file-crypto.go
@@ -1,0 +1,44 @@
+package cryptoCmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	anbuCrypto "github.com/tanq16/anbu/internal/crypto"
+	u "github.com/tanq16/anbu/utils"
+)
+
+var fileCryptoFlags struct {
+	password string
+	decrypt  bool
+}
+
+var FileCryptoCmd = &cobra.Command{
+	Use:     "file-crypt <file-path>",
+	Aliases: []string{"fc"},
+	Short:   "Encrypt or decrypt files using AES-256-GCM with a password-based symmetric encryption",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if fileCryptoFlags.password == "" {
+			u.PrintFatal("no password specified", nil)
+		}
+		if fileCryptoFlags.decrypt {
+			outputPath, err := anbuCrypto.DecryptFileSymmetric(args[0], fileCryptoFlags.password)
+			if err != nil {
+				u.PrintFatal("decryption failed", err)
+			}
+			u.PrintGeneric(fmt.Sprintf("\nFile decrypted: %s", u.FSuccess(outputPath)))
+		} else {
+			outputPath, err := anbuCrypto.EncryptFileSymmetric(args[0], fileCryptoFlags.password)
+			if err != nil {
+				u.PrintFatal("encryption failed", err)
+			}
+			u.PrintGeneric(fmt.Sprintf("\nFile encrypted: %s", u.FSuccess(outputPath)))
+		}
+	},
+}
+
+func init() {
+	FileCryptoCmd.Flags().StringVarP(&fileCryptoFlags.password, "password", "p", "", "Encryption password")
+	FileCryptoCmd.Flags().BoolVarP(&fileCryptoFlags.decrypt, "decrypt", "d", false, "Decrypt the file instead of encrypting")
+}

--- a/cmd/crypto-cmd/key-pair.go
+++ b/cmd/crypto-cmd/key-pair.go
@@ -1,0 +1,50 @@
+package cryptoCmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	anbuCrypto "github.com/tanq16/anbu/internal/crypto"
+	u "github.com/tanq16/anbu/utils"
+)
+
+var keyPairFlags struct {
+	outputPath string
+	keySize    int
+	sshFormat  bool
+}
+
+var KeyPairCmd = &cobra.Command{
+	Use:     "key-pair",
+	Aliases: []string{"kp"},
+	Short:   "Generate RSA key pairs in PEM or SSH format",
+	Run: func(cmd *cobra.Command, args []string) {
+		keyName := filepath.Base(keyPairFlags.outputPath)
+		keyDir := filepath.Dir(keyPairFlags.outputPath)
+		var result *anbuCrypto.KeyPairResult
+		var err error
+		if keyPairFlags.sshFormat {
+			result, err = anbuCrypto.GenerateSSHKeyPair(keyDir, keyName, keyPairFlags.keySize)
+		} else {
+			result, err = anbuCrypto.GenerateKeyPair(keyDir, keyName, keyPairFlags.keySize)
+		}
+		if err != nil {
+			u.PrintFatal("key pair generation failed", err)
+		}
+		u.LineBreak()
+		if keyPairFlags.sshFormat {
+			u.PrintGeneric(fmt.Sprintf("SSH key pair (%d bits) generated", result.KeySize))
+		} else {
+			u.PrintGeneric(fmt.Sprintf("RSA key pair (%d bits) generated", result.KeySize))
+		}
+		u.PrintGeneric(fmt.Sprintf("Public key: %s", u.FInfo(result.PublicKeyPath)))
+		u.PrintGeneric(fmt.Sprintf("Private key: %s", u.FInfo(result.PrivateKeyPath)))
+	},
+}
+
+func init() {
+	KeyPairCmd.Flags().StringVarP(&keyPairFlags.outputPath, "output-path", "o", "./anbu-key", "Output path and name for the key files")
+	KeyPairCmd.Flags().IntVarP(&keyPairFlags.keySize, "key-size", "k", 2048, "RSA key size (e.g., 2048, 3072, 4096)")
+	KeyPairCmd.Flags().BoolVarP(&keyPairFlags.sshFormat, "ssh", "s", false, "Generate keys in SSH format instead of PEM")
+}

--- a/cmd/generics-cmd/stringgen.go
+++ b/cmd/generics-cmd/stringgen.go
@@ -198,7 +198,7 @@ var passphraseCmd = &cobra.Command{
 
 func init() {
 	seqCmd.Flags().IntVarP(&seqLength, "length", "l", 100, "Length of sequence string")
-	ruidCmd.Flags().IntVarP(&ruidLength, "length", "l", 18, "Length of RUID (1-32)")
+	ruidCmd.Flags().IntVarP(&ruidLength, "length", "l", 18, "Length of RUID (1-30)")
 
 	passwordCmd.Flags().IntVarP(&passwordLength, "length", "l", 12, "Length of password")
 	passwordCmd.Flags().BoolVarP(&passwordSimple, "simple", "s", false, "Use simple lowercase password")

--- a/cmd/generics-cmd/stringgen.go
+++ b/cmd/generics-cmd/stringgen.go
@@ -8,95 +8,210 @@ import (
 	u "github.com/tanq16/anbu/utils"
 )
 
+var (
+	passwordLength int
+	passwordSimple bool
+
+	passphraseLength     int
+	passphraseSeparator  string
+	passphraseCapitalize bool
+
+	seqLength  int
+	ruidLength int
+)
+
 var StringCmd = &cobra.Command{
-	Use:     "string",
+	Use:     "string [length]",
 	Aliases: []string{"s"},
 	Short:   "Generate random strings, sequences, passwords, and passphrases",
 	Long: `Generate random strings, sequences, passwords, and passphrases.
+
 Examples:
-  anbu string 23                       # generate 23 (100 if not specified) random alphanumeric chars
-  anbu string seq 29                   # prints "abcdefghijklmnopqrstuvxyz" until desired length
-  anbu string rep 23 str2rep           # prints "str2repstr2rep...23 times"
-  anbu string uuid                     # generates a uuid
-  anbu string ruid 16                  # generates a short uuid of length b/w 1-32
-  anbu string suid                     # generates a short uuid of length 18
+  anbu string 23                       # generate 23 random alphanumeric chars (default 100)
+  anbu string seq 29                   # prints "abcdefghijklmnopqrstuvwxyz" until desired length
+  anbu string rep 23 str2rep           # prints "str2rep" repeated 23 times
+  anbu string uuid                     # generates a UUID v4
+  anbu string ruid 16                  # generates a short UUID of length 1-32
+  anbu string suid                     # generates a short UUID of length 18
   anbu string password                 # generate a 12-character complex password
   anbu string password 16              # generate a 16-character complex password
-  anbu string password 8 simple        # generate an 8-letter lowercase password
+  anbu string password 8 -s            # generate an 8-letter simple password
   anbu string passphrase               # generate a 3-word passphrase with hyphens
-  anbu string passphrase 5             # generate a 5-word passphrase with hyphens
-  anbu string passphrase 4 '@'         # generate a 4-word passphrase with a custom separator`,
+  anbu string passphrase -l 5          # generate a 5-word passphrase
+  anbu string passphrase -l 4 -s '@'   # generate a 4-word passphrase with a custom separator
+  anbu string passphrase -c           # generate a passphrase with capitalization and digits`,
 	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			anbuGenerics.GenerateRandomString(0)
-			return
-		}
-		if len, err := strconv.Atoi(args[0]); err == nil {
-			anbuGenerics.GenerateRandomString(len)
-			return
-		}
-		if args[0] == "seq" {
-			if len(args) < 2 {
-				u.PrintFatal("Missing length for sequence command", nil)
+		length := 100
+		if len(args) > 0 {
+			if l, err := strconv.Atoi(args[0]); err == nil {
+				length = l
 			}
-			length, err := strconv.Atoi(args[1])
-			if err != nil {
-				u.PrintFatal("Not a valid length", err)
-			}
-			anbuGenerics.GenerateSequenceString(length)
+		}
+		str, err := anbuGenerics.GenerateRandomString(length)
+		if err != nil {
+			u.PrintError("Failed to generate random string", err)
 			return
 		}
-		if args[0] == "rep" {
-			if len(args) < 3 {
-				u.PrintFatal("Missing count or string for repetition", nil)
-			}
-			count, err := strconv.Atoi(args[1])
-			if err != nil {
-				u.PrintFatal("Not a valid count", err)
-			}
-			anbuGenerics.GenerateRepetitionString(count, args[2])
-			return
-		}
-		if args[0] == "uuid" {
-			anbuGenerics.GenerateUUIDString()
-			return
-		}
-		if args[0] == "ruid" {
-			if len(args) < 2 {
-				u.PrintFatal("Missing length for RUID command", nil)
-			}
-			anbuGenerics.GenerateRUIDString(args[1])
-			return
-		}
-		if args[0] == "suid" {
-			anbuGenerics.GenerateRUIDString("18")
-			return
-		}
-		if args[0] == "password" {
-			if len(args) < 2 {
-				anbuGenerics.GeneratePassword("12", false)
-			} else if len(args) == 2 {
-				anbuGenerics.GeneratePassword(args[1], false)
-			} else if len(args) == 3 {
-				anbuGenerics.GeneratePassword(args[1], true)
-			}
-			return
-		}
-		if args[0] == "passphrase" {
-			if len(args) < 2 {
-				anbuGenerics.GeneratePassPhrase("3", "-", false)
-			} else if len(args) == 2 {
-				anbuGenerics.GeneratePassPhrase(args[1], "-", false)
-			} else if len(args) == 3 {
-				if args[2] == "simple" {
-					anbuGenerics.GeneratePassPhrase(args[1], "-", true)
-				} else {
-					anbuGenerics.GeneratePassPhrase(args[1], args[2], false)
-				}
-			}
-			return
-		}
-		cmd.Help()
+		u.PrintGeneric(str)
 	},
+}
+
+var seqCmd = &cobra.Command{
+	Use:   "seq [length]",
+	Short: "Generate sequence string",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		length := seqLength
+		if len(args) > 0 {
+			if l, err := strconv.Atoi(args[0]); err == nil {
+				length = l
+			}
+		}
+		u.PrintGeneric(anbuGenerics.GenerateSequenceString(length))
+	},
+}
+
+var repCmd = &cobra.Command{
+	Use:   "rep <count> <string>",
+	Short: "Generate repeated string",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		count, err := strconv.Atoi(args[0])
+		if err != nil {
+			u.PrintError("Invalid repetition count", err)
+			return
+		}
+		u.PrintGeneric(anbuGenerics.GenerateRepetitionString(count, args[1]))
+	},
+}
+
+var uuidCmd = &cobra.Command{
+	Use:   "uuid",
+	Short: "Generate a UUID v4",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		str, err := anbuGenerics.GenerateUUIDString()
+		if err != nil {
+			u.PrintError("Failed to generate UUID", err)
+			return
+		}
+		u.PrintGeneric(str)
+	},
+}
+
+var ruidCmd = &cobra.Command{
+	Use:   "ruid [length]",
+	Short: "Generate a short UUID",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		length := ruidLength
+		if len(args) > 0 {
+			if l, err := strconv.Atoi(args[0]); err == nil {
+				length = l
+			}
+		}
+		str, err := anbuGenerics.GenerateRUIDString(length)
+		if err != nil {
+			u.PrintError("Failed to generate RUID", err)
+			return
+		}
+		u.PrintGeneric(str)
+	},
+}
+
+var suidCmd = &cobra.Command{
+	Use:   "suid",
+	Short: "Generate a short UUID of length 18",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		str, err := anbuGenerics.GenerateRUIDString(18)
+		if err != nil {
+			u.PrintError("Failed to generate SUID", err)
+			return
+		}
+		u.PrintGeneric(str)
+	},
+}
+
+var passwordCmd = &cobra.Command{
+	Use:   "password [length]",
+	Short: "Generate a random password",
+	Args:  cobra.ArbitraryArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		length := passwordLength
+		simple := passwordSimple
+		if len(args) > 0 {
+			if l, err := strconv.Atoi(args[0]); err == nil {
+				length = l
+			}
+		}
+		if len(args) > 1 && args[1] == "simple" {
+			simple = true
+		}
+		pwd, err := anbuGenerics.GeneratePassword(length, simple)
+		if err != nil {
+			u.PrintError("Failed to generate password", err)
+			return
+		}
+		u.PrintGeneric(pwd)
+	},
+}
+
+var passphraseCmd = &cobra.Command{
+	Use:   "passphrase [length]",
+	Short: "Generate a passphrase",
+	Args:  cobra.ArbitraryArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		length := passphraseLength
+		sep := passphraseSeparator
+		cap := passphraseCapitalize
+
+		if len(args) > 0 {
+			if l, err := strconv.Atoi(args[0]); err == nil {
+				length = l
+			}
+		}
+		if len(args) > 1 {
+			if args[1] == "simple" {
+				cap = false
+			} else {
+				sep = args[1]
+			}
+		}
+		if len(args) > 2 {
+			if args[2] == "simple" {
+				cap = false
+			} else {
+				sep = args[2]
+			}
+		}
+
+		phrase, err := anbuGenerics.GeneratePassPhrase(length, sep, cap)
+		if err != nil {
+			u.PrintError("Failed to generate passphrase", err)
+			return
+		}
+		u.PrintGeneric(phrase)
+	},
+}
+
+func init() {
+	seqCmd.Flags().IntVarP(&seqLength, "length", "l", 100, "Length of sequence string")
+	ruidCmd.Flags().IntVarP(&ruidLength, "length", "l", 18, "Length of RUID (1-32)")
+
+	passwordCmd.Flags().IntVarP(&passwordLength, "length", "l", 12, "Length of password")
+	passwordCmd.Flags().BoolVarP(&passwordSimple, "simple", "s", false, "Use simple lowercase password")
+
+	passphraseCmd.Flags().IntVarP(&passphraseLength, "length", "l", 3, "Number of words in passphrase")
+	passphraseCmd.Flags().StringVarP(&passphraseSeparator, "separator", "s", "-", "Word separator")
+	passphraseCmd.Flags().BoolVarP(&passphraseCapitalize, "capitalize", "c", false, "Capitalize words and add digits")
+
+	StringCmd.AddCommand(seqCmd)
+	StringCmd.AddCommand(repCmd)
+	StringCmd.AddCommand(uuidCmd)
+	StringCmd.AddCommand(ruidCmd)
+	StringCmd.AddCommand(suidCmd)
+	StringCmd.AddCommand(passwordCmd)
+	StringCmd.AddCommand(passphraseCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,8 @@ func init() {
 	rootCmd.AddCommand(genericsCmd.DuplicatesCmd)
 
 	rootCmd.AddCommand(cryptoCmd.SecretsCmd)
+	rootCmd.AddCommand(cryptoCmd.KeyPairCmd)
+	rootCmd.AddCommand(cryptoCmd.FileCryptoCmd)
 
 	rootCmd.AddCommand(networkCmd.TunnelCmd)
 	rootCmd.AddCommand(networkCmd.HTTPServerCmd)

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -1,0 +1,90 @@
+package anbuCrypto
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKeyPairGeneration(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("RSA Key Pair", func(t *testing.T) {
+		res, err := GenerateKeyPair(tempDir, "testrsa", 2048)
+		if err != nil {
+			t.Fatalf("GenerateKeyPair failed: %v", err)
+		}
+		if res.KeySize != 2048 {
+			t.Errorf("expected KeySize 2048, got %d", res.KeySize)
+		}
+		if _, err := os.Stat(res.PrivateKeyPath); err != nil {
+			t.Errorf("private key file missing: %v", err)
+		}
+		if _, err := os.Stat(res.PublicKeyPath); err != nil {
+			t.Errorf("public key file missing: %v", err)
+		}
+
+		info, err := os.Stat(res.PrivateKeyPath)
+		if err != nil {
+			t.Fatalf("failed to stat private key: %v", err)
+		}
+		if mode := info.Mode().Perm(); mode != 0600 {
+			t.Errorf("expected mode 0600, got %o", mode)
+		}
+	})
+
+	t.Run("SSH Key Pair", func(t *testing.T) {
+		res, err := GenerateSSHKeyPair(tempDir, "testssh", 2048)
+		if err != nil {
+			t.Fatalf("GenerateSSHKeyPair failed: %v", err)
+		}
+		if _, err := os.Stat(res.PrivateKeyPath); err != nil {
+			t.Errorf("SSH private key missing: %v", err)
+		}
+		if _, err := os.Stat(res.PublicKeyPath); err != nil {
+			t.Errorf("SSH public key missing: %v", err)
+		}
+	})
+}
+
+func TestSymmetricFileEncryption(t *testing.T) {
+	tempDir := t.TempDir()
+	samplePath := filepath.Join(tempDir, "secret.txt")
+	originalContent := "super secret payload data 123"
+
+	if err := os.WriteFile(samplePath, []byte(originalContent), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	password := "correct-horse-battery-staple"
+
+	encPath, err := EncryptFileSymmetric(samplePath, password)
+	if err != nil {
+		t.Fatalf("EncryptFileSymmetric failed: %v", err)
+	}
+
+	if _, err := os.Stat(encPath); err != nil {
+		t.Fatalf("encrypted file missing: %v", err)
+	}
+
+	decPath, err := DecryptFileSymmetric(encPath, password)
+	if err != nil {
+		t.Fatalf("DecryptFileSymmetric failed: %v", err)
+	}
+
+	decryptedContent, err := os.ReadFile(decPath)
+	if err != nil {
+		t.Fatalf("failed to read decrypted file: %v", err)
+	}
+
+	if string(decryptedContent) != originalContent {
+		t.Errorf("expected content %q, got %q", originalContent, string(decryptedContent))
+	}
+
+	t.Run("Wrong Password", func(t *testing.T) {
+		_, err := DecryptFileSymmetric(encPath, "wrong-password")
+		if err == nil {
+			t.Error("expected error decrypting with wrong password, got nil")
+		}
+	})
+}

--- a/internal/crypto/file-symm-encrypt.go
+++ b/internal/crypto/file-symm-encrypt.go
@@ -1,0 +1,78 @@
+package anbuCrypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+var encryptionSalt = []byte("anbu-file-crypt-v1")
+
+func EncryptFileSymmetric(inputPath string, password string) (string, error) {
+	content, err := os.ReadFile(inputPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read input file: %w", err)
+	}
+	key := pbkdf2.Key([]byte(password), encryptionSalt, 100000, 32, sha256.New)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+	ciphertext := gcm.Seal(nonce, nonce, content, nil)
+	encoded := base64.StdEncoding.EncodeToString(ciphertext)
+	outputPath := inputPath + ".enc"
+	if err := os.WriteFile(outputPath, []byte(encoded), 0644); err != nil {
+		return "", fmt.Errorf("failed to write encrypted file: %w", err)
+	}
+	return outputPath, nil
+}
+
+func DecryptFileSymmetric(inputPath string, password string) (string, error) {
+	encContent, err := os.ReadFile(inputPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read input file: %w", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(string(encContent))
+	if err != nil {
+		return "", fmt.Errorf("failed to decode base64 content: %w", err)
+	}
+	key := pbkdf2.Key([]byte(password), encryptionSalt, 100000, 32, sha256.New)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+	nonceSize := gcm.NonceSize()
+	if len(decoded) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	nonce, ciphertext := decoded[:nonceSize], decoded[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt: %w", err)
+	}
+	outputPath := strings.TrimSuffix(inputPath, ".enc")
+	if err := os.WriteFile(outputPath, plaintext, 0644); err != nil {
+		return "", fmt.Errorf("failed to write decrypted file: %w", err)
+	}
+	return outputPath, nil
+}

--- a/internal/crypto/key-pair.go
+++ b/internal/crypto/key-pair.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -31,7 +32,7 @@ func GenerateKeyPair(outputDir, name string, keySize int) (*KeyPairResult, error
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
 	}
-	privateKeyPath := fmt.Sprintf("%s/%s.private.pem", outputDir, name)
+	privateKeyPath := filepath.Join(outputDir, name+".private.pem")
 	privateKeyFile, err := os.OpenFile(privateKeyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private key file: %w", err)
@@ -50,7 +51,7 @@ func GenerateKeyPair(outputDir, name string, keySize int) (*KeyPairResult, error
 		Type:  "PUBLIC KEY",
 		Bytes: publicKeyBytes,
 	}
-	publicKeyPath := fmt.Sprintf("%s/%s.public.pem", outputDir, name)
+	publicKeyPath := filepath.Join(outputDir, name+".public.pem")
 	publicKeyFile, err := os.Create(publicKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create public key file: %w", err)
@@ -82,7 +83,7 @@ func GenerateSSHKeyPair(outputDir, name string, keySize int) (*KeyPairResult, er
 	}
 	sshPublicKeyBytes := ssh.MarshalAuthorizedKey(publicKey)
 
-	publicKeyPath := fmt.Sprintf("%s/%s.pub", outputDir, name)
+	publicKeyPath := filepath.Join(outputDir, name+".pub")
 	if err := os.WriteFile(publicKeyPath, sshPublicKeyBytes, 0644); err != nil {
 		return nil, fmt.Errorf("failed to write SSH public key file: %w", err)
 	}
@@ -90,7 +91,7 @@ func GenerateSSHKeyPair(outputDir, name string, keySize int) (*KeyPairResult, er
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
 	}
-	privateKeyPath := fmt.Sprintf("%s/%s", outputDir, name)
+	privateKeyPath := filepath.Join(outputDir, name)
 	privateKeyFile, err := os.OpenFile(privateKeyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private key file: %w", err)

--- a/internal/crypto/key-pair.go
+++ b/internal/crypto/key-pair.go
@@ -1,0 +1,109 @@
+package anbuCrypto
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type KeyPairResult struct {
+	KeySize        int
+	PublicKeyPath  string
+	PrivateKeyPath string
+}
+
+func GenerateKeyPair(outputDir, name string, keySize int) (*KeyPairResult, error) {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate RSA key: %w", err)
+	}
+	publicKey := &privateKey.PublicKey
+	privateKeyBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+	privateKeyPath := fmt.Sprintf("%s/%s.private.pem", outputDir, name)
+	privateKeyFile, err := os.OpenFile(privateKeyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create private key file: %w", err)
+	}
+	if err := pem.Encode(privateKeyFile, privateKeyBlock); err != nil {
+		privateKeyFile.Close()
+		return nil, fmt.Errorf("failed to write private key to file: %w", err)
+	}
+	privateKeyFile.Close()
+
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+	publicKeyBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: publicKeyBytes,
+	}
+	publicKeyPath := fmt.Sprintf("%s/%s.public.pem", outputDir, name)
+	publicKeyFile, err := os.Create(publicKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create public key file: %w", err)
+	}
+	if err := pem.Encode(publicKeyFile, publicKeyBlock); err != nil {
+		publicKeyFile.Close()
+		return nil, fmt.Errorf("failed to write public key to file: %w", err)
+	}
+	publicKeyFile.Close()
+
+	return &KeyPairResult{
+		KeySize:        keySize,
+		PublicKeyPath:  publicKeyPath,
+		PrivateKeyPath: privateKeyPath,
+	}, nil
+}
+
+func GenerateSSHKeyPair(outputDir, name string, keySize int) (*KeyPairResult, error) {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	privateKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate RSA key: %w", err)
+	}
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SSH public key: %w", err)
+	}
+	sshPublicKeyBytes := ssh.MarshalAuthorizedKey(publicKey)
+
+	publicKeyPath := fmt.Sprintf("%s/%s.pub", outputDir, name)
+	if err := os.WriteFile(publicKeyPath, sshPublicKeyBytes, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write SSH public key file: %w", err)
+	}
+	privatePEM := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+	privateKeyPath := fmt.Sprintf("%s/%s", outputDir, name)
+	privateKeyFile, err := os.OpenFile(privateKeyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create private key file: %w", err)
+	}
+	if err := pem.Encode(privateKeyFile, privatePEM); err != nil {
+		privateKeyFile.Close()
+		return nil, fmt.Errorf("failed to write private key to file: %w", err)
+	}
+	privateKeyFile.Close()
+
+	return &KeyPairResult{
+		KeySize:        keySize,
+		PublicKeyPath:  publicKeyPath,
+		PrivateKeyPath: privateKeyPath,
+	}, nil
+}

--- a/internal/generics/password-gen.go
+++ b/internal/generics/password-gen.go
@@ -2,71 +2,124 @@ package anbuGenerics
 
 import (
 	cryptoRand "crypto/rand"
-	"math/rand"
-	"strconv"
+	"math/big"
 	"strings"
-
-	u "github.com/tanq16/anbu/utils"
 )
 
-func GeneratePassword(lengthS string, simple bool) {
-	length, err := strconv.Atoi(lengthS)
+const (
+	lowerSet   = "abcdefghijklmnopqrstuvwxyz"
+	upperSet   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	digitSet   = "0123456789"
+	specialSet = "!@#$%^&*()-_=+[]{}|;:,.<>?/"
+)
+
+func cryptoRandInt(max int) (int, error) {
+	n, err := cryptoRand.Int(cryptoRand.Reader, big.NewInt(int64(max)))
 	if err != nil {
-		u.PrintFatal("invalid length", err)
+		return 0, err
 	}
-	if length <= 0 {
-		u.PrintWarn("length must be greater than 0; using 15", nil)
-		length = 15
-	}
-	alphabet := "abcdefghijklmnopqrstuvwxyz"
-	if !simple {
-		alphabet += "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?/"
-	}
-	var result strings.Builder
-	for result.Len() < length {
-		randomBytes := make([]byte, length)
-		cryptoRand.Read(randomBytes)
-		for _, b := range randomBytes {
-			result.WriteByte(alphabet[b%byte(len(alphabet))])
-		}
-	}
-	u.PrintGeneric(result.String()[:length])
+	return int(n.Int64()), nil
 }
 
-func GeneratePassPhrase(lengthS string, separator string, simple bool) {
-	length, err := strconv.Atoi(lengthS)
-	if err != nil {
-		u.PrintFatal("invalid length", err)
+func GeneratePassword(length int, simple bool) (string, error) {
+	if length <= 0 {
+		length = 12
 	}
-	if length < 2 || length > 50 {
-		u.PrintWarn("length must be between 2 to 50; using 3", nil)
-		length = 3
+	if simple {
+		var sb strings.Builder
+		sb.Grow(length)
+		for range length {
+			idx, err := cryptoRandInt(len(lowerSet))
+			if err != nil {
+				return "", err
+			}
+			sb.WriteByte(lowerSet[idx])
+		}
+		return sb.String(), nil
+	}
+
+	fullCharset := lowerSet + upperSet + digitSet + specialSet
+	buf := make([]byte, length)
+
+	if length >= 4 {
+		lIdx, err := cryptoRandInt(len(lowerSet))
+		if err != nil {
+			return "", err
+		}
+		uIdx, err := cryptoRandInt(len(upperSet))
+		if err != nil {
+			return "", err
+		}
+		dIdx, err := cryptoRandInt(len(digitSet))
+		if err != nil {
+			return "", err
+		}
+		sIdx, err := cryptoRandInt(len(specialSet))
+		if err != nil {
+			return "", err
+		}
+		buf[0] = lowerSet[lIdx]
+		buf[1] = upperSet[uIdx]
+		buf[2] = digitSet[dIdx]
+		buf[3] = specialSet[sIdx]
+
+		for i := 4; i < length; i++ {
+			cIdx, err := cryptoRandInt(len(fullCharset))
+			if err != nil {
+				return "", err
+			}
+			buf[i] = fullCharset[cIdx]
+		}
+
+		for i := length - 1; i > 0; i-- {
+			j, err := cryptoRandInt(i + 1)
+			if err != nil {
+				return "", err
+			}
+			buf[i], buf[j] = buf[j], buf[i]
+		}
+	} else {
+		for i := 0; i < length; i++ {
+			cIdx, err := cryptoRandInt(len(fullCharset))
+			if err != nil {
+				return "", err
+			}
+			buf[i] = fullCharset[cIdx]
+		}
+	}
+
+	return string(buf), nil
+}
+
+func GeneratePassPhrase(wordsCount int, separator string, capitalize bool) (string, error) {
+	if wordsCount < 1 || wordsCount > 50 {
+		wordsCount = 3
 	}
 	if separator == "" {
 		separator = "-"
 	}
-	if len(separator) > 1 {
-		u.PrintWarn("separator must be a single character; using -", nil)
-	}
-	numberList := "0123456789"
+
 	var result strings.Builder
-	complexified := false
-	for i := range length {
-		randomIndex := rand.Intn(len(passphraseWords))
-		toWrite := passphraseWords[randomIndex]
-		if !simple && rand.Intn(2) == 1 {
-			toWrite = strings.ToUpper(string(toWrite[0])) + toWrite[1:] + string(numberList[rand.Intn(10)])
-			complexified = true
+	for i := range wordsCount {
+		idx, err := cryptoRandInt(len(passphraseWords))
+		if err != nil {
+			return "", err
 		}
-		if i == length-1 && !simple && !complexified {
-			toWrite = strings.ToUpper(string(toWrite[0])) + toWrite[1:] + string(numberList[rand.Intn(10)])
+		word := passphraseWords[idx]
+		if capitalize {
+			numIdx, err := cryptoRandInt(10)
+			if err != nil {
+				return "", err
+			}
+			word = strings.ToUpper(string(word[0])) + word[1:] + string(digitSet[numIdx])
 		}
-		result.WriteString(toWrite)
-		if i < length-1 {
+		result.WriteString(word)
+		if i < wordsCount-1 {
 			result.WriteString(separator)
 		}
 	}
-	u.PrintGeneric(result.String())
+
+	return result.String(), nil
 }
 
 var passphraseWords = []string{

--- a/internal/generics/string-gen.go
+++ b/internal/generics/string-gen.go
@@ -59,14 +59,16 @@ func GenerateUUIDString() (string, error) {
 }
 
 func GenerateRUIDString(length int) (string, error) {
-	if length <= 0 || length > 32 {
+	if length <= 0 || length > 30 {
 		length = 18
 	}
 	u, err := uuid.NewRandom()
 	if err != nil {
 		return "", err
 	}
-	cleanUUID := strings.ReplaceAll(u.String(), "-", "")
-	return cleanUUID[:length], nil
+	str := u.String()
+	// Strip hyphens and constant UUID v4 version (index 14) and variant (index 19) characters
+	shortUUID := str[0:8] + str[9:13] + str[15:18] + str[20:23] + str[24:]
+	return shortUUID[:length], nil
 }
 

--- a/internal/generics/string-gen.go
+++ b/internal/generics/string-gen.go
@@ -1,79 +1,72 @@
 package anbuGenerics
 
 import (
-	"crypto/rand"
-	"encoding/base64"
-	"strconv"
+	cryptoRand "crypto/rand"
+	"math/big"
 	"strings"
 
 	"github.com/google/uuid"
-	u "github.com/tanq16/anbu/utils"
 )
 
-func GenerateRandomString(length int) {
+const randomCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func GenerateRandomString(length int) (string, error) {
 	if length <= 0 {
 		length = 100
 	}
-	randomBytes := make([]byte, length)
-	_, err := rand.Read(randomBytes)
-	if err != nil {
-		u.PrintFatal("failed to generate random bytes", err)
-	}
-	encoded := base64.StdEncoding.EncodeToString(randomBytes)
-	encoded = strings.Map(func(r rune) rune {
-		switch r {
-		case '=', '+', '/', '\n':
-			return -1
-		default:
-			return r
+	var sb strings.Builder
+	sb.Grow(length)
+	charsetLen := big.NewInt(int64(len(randomCharset)))
+	for range length {
+		idx, err := cryptoRand.Int(cryptoRand.Reader, charsetLen)
+		if err != nil {
+			return "", err
 		}
-	}, encoded)
-	if len(encoded) > length {
-		encoded = encoded[:length]
+		sb.WriteByte(randomCharset[idx.Int64()])
 	}
-	u.PrintGeneric(encoded)
+	return sb.String(), nil
 }
 
-func GenerateSequenceString(length int) {
+func GenerateSequenceString(length int) string {
 	if length <= 0 {
-		u.PrintWarn("length must be greater than 0; using 100", nil)
 		length = 100
 	}
-	alphabet := "abcdefghijklmnopqrstuvxyz"
+	alphabet := "abcdefghijklmnopqrstuvwxyz"
 	var result strings.Builder
 	for result.Len() < length {
 		result.WriteString(alphabet)
 	}
-	u.PrintGeneric(result.String()[:length])
+	return result.String()[:length]
 }
 
-func GenerateRepetitionString(count int, str string) {
+func GenerateRepetitionString(count int, str string) string {
 	if count <= 0 {
-		u.PrintWarn("count must be greater than 0; using 10", nil)
 		count = 10
 	}
 	var result strings.Builder
 	for range count {
 		result.WriteString(str)
 	}
-	u.PrintGeneric(result.String())
+	return result.String()
 }
 
-func GenerateUUIDString() {
-	uuid, _ := uuid.NewRandom()
-	u.PrintGeneric(uuid.String())
-}
-
-func GenerateRUIDString(len string) {
-	length, err := strconv.Atoi(len)
+func GenerateUUIDString() (string, error) {
+	u, err := uuid.NewRandom()
 	if err != nil {
-		u.PrintFatal("not a valid length", err)
+		return "", err
 	}
-	if length <= 0 || length > 30 {
-		u.PrintWarn("length must be between 1 and 30; using 18", nil)
+	return u.String(), nil
+}
+
+func GenerateRUIDString(length int) (string, error) {
+	if length <= 0 || length > 32 {
 		length = 18
 	}
-	uuid, _ := uuid.NewRandom()
-	shortUUID := uuid.String()[0:8] + uuid.String()[9:13] + uuid.String()[15:18] + uuid.String()[20:23] + uuid.String()[24:]
-	u.PrintGeneric(shortUUID[:length])
+	u, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+	cleanUUID := strings.ReplaceAll(u.String(), "-", "")
+	return cleanUUID[:length], nil
 }
+

--- a/internal/generics/string-gen_test.go
+++ b/internal/generics/string-gen_test.go
@@ -49,9 +49,9 @@ func TestGenerateRUIDString(t *testing.T) {
 		wantLength int
 	}{
 		{"default for invalid <=0", 0, 18},
-		{"default for invalid >32", 35, 18},
+		{"default for invalid >30", 35, 18},
 		{"valid length 16", 16, 16},
-		{"max length 32", 32, 32},
+		{"max length 30", 30, 30},
 	}
 
 	for _, tt := range tests {

--- a/internal/generics/string-gen_test.go
+++ b/internal/generics/string-gen_test.go
@@ -1,0 +1,126 @@
+package anbuGenerics
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestGenerateRandomString(t *testing.T) {
+	tests := []struct {
+		name       string
+		length     int
+		wantLength int
+	}{
+		{"default length", 0, 100},
+		{"negative length", -5, 100},
+		{"custom length 10", 10, 10},
+		{"custom length 45", 45, 45},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateRandomString(tt.length)
+			if err != nil {
+				t.Fatalf("GenerateRandomString(%d) error = %v", tt.length, err)
+			}
+			if len(got) != tt.wantLength {
+				t.Errorf("GenerateRandomString(%d) len = %d, want %d", tt.length, len(got), tt.wantLength)
+			}
+		})
+	}
+}
+
+func TestGenerateSequenceString(t *testing.T) {
+	seq := GenerateSequenceString(26)
+	wantSeq := "abcdefghijklmnopqrstuvwxyz"
+	if seq != wantSeq {
+		t.Errorf("GenerateSequenceString(26) = %q, want %q", seq, wantSeq)
+	}
+	if !strings.Contains(seq, "w") {
+		t.Errorf("GenerateSequenceString(26) missing letter 'w'")
+	}
+}
+
+func TestGenerateRUIDString(t *testing.T) {
+	tests := []struct {
+		name       string
+		length     int
+		wantLength int
+	}{
+		{"default for invalid <=0", 0, 18},
+		{"default for invalid >32", 35, 18},
+		{"valid length 16", 16, 16},
+		{"max length 32", 32, 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateRUIDString(tt.length)
+			if err != nil {
+				t.Fatalf("GenerateRUIDString(%d) error = %v", tt.length, err)
+			}
+			if len(got) != tt.wantLength {
+				t.Errorf("GenerateRUIDString(%d) len = %d, want %d", tt.length, len(got), tt.wantLength)
+			}
+		})
+	}
+}
+
+func TestGeneratePassword(t *testing.T) {
+	t.Run("simple password", func(t *testing.T) {
+		pwd, err := GeneratePassword(12, true)
+		if err != nil {
+			t.Fatalf("GeneratePassword(12, true) error = %v", err)
+		}
+		if len(pwd) != 12 {
+			t.Errorf("len = %d, want 12", len(pwd))
+		}
+		matched, _ := regexp.MatchString("^[a-z]+$", pwd)
+		if !matched {
+			t.Errorf("simple password contains non-lowercase chars: %q", pwd)
+		}
+	})
+
+	t.Run("complex password guarantees character set diversity", func(t *testing.T) {
+		pwd, err := GeneratePassword(16, false)
+		if err != nil {
+			t.Fatalf("GeneratePassword(16, false) error = %v", err)
+		}
+		if len(pwd) != 16 {
+			t.Errorf("len = %d, want 16", len(pwd))
+		}
+		hasLower := strings.ContainsAny(pwd, lowerSet)
+		hasUpper := strings.ContainsAny(pwd, upperSet)
+		hasDigit := strings.ContainsAny(pwd, digitSet)
+		hasSpecial := strings.ContainsAny(pwd, specialSet)
+
+		if !hasLower || !hasUpper || !hasDigit || !hasSpecial {
+			t.Errorf("complex password %q missing set: lower=%v upper=%v digit=%v special=%v", pwd, hasLower, hasUpper, hasDigit, hasSpecial)
+		}
+	})
+}
+
+func TestGeneratePassPhrase(t *testing.T) {
+	t.Run("default simple passphrase", func(t *testing.T) {
+		phrase, err := GeneratePassPhrase(3, "-", false)
+		if err != nil {
+			t.Fatalf("GeneratePassPhrase error = %v", err)
+		}
+		parts := strings.Split(phrase, "-")
+		if len(parts) != 3 {
+			t.Errorf("got %d parts, want 3 in %q", len(parts), phrase)
+		}
+	})
+
+	t.Run("custom separator and capitalization", func(t *testing.T) {
+		phrase, err := GeneratePassPhrase(4, "@", true)
+		if err != nil {
+			t.Fatalf("GeneratePassPhrase error = %v", err)
+		}
+		parts := strings.Split(phrase, "@")
+		if len(parts) != 4 {
+			t.Errorf("got %d parts, want 4 in %q", len(parts), phrase)
+		}
+	})
+}


### PR DESCRIPTION
## Description
Reinstates and refactors core `crypto` and `string` generation commands:

### Crypto Commands
- **`anbu key-pair`**: Generates RSA key pairs in PEM format or OpenSSH authorized_keys format (`.pub` and private key). Sets private key file permissions strictly to `0600`.
- **`anbu file-crypt`** / **`anbu fc`**: Performs AES-256-GCM symmetric file encryption and decryption using PBKDF2 password-based key derivation.

### String Commands (`anbu string` / `anbu s`)
- **Modular Cobra Subcommands**: Refactored `anbu string` into modular Cobra subcommands (`seq`, `rep`, `uuid`, `ruid`, `suid`, `password`, `passphrase`) with flag support (`--length`, `--separator`, `--capitalize`, `--simple`) while preserving backward-compatible positional usage.
- **Cryptographic Security**: Replaced weak PRNG `math/rand` and Base64 hacks with `crypto/rand` for passphrases, random strings, and passwords. Eliminates modulo bias and guarantees password character diversity.
- **RUID Constant Bit Stripping**: Preserved RUID selective slicing (`[0:8] + [9:13] + [15:18] + [20:23] + [24:]`) to strip hyphens along with the constant UUID v4 version digit (index 14) and variant digit (index 19), maximizing random entropy density for short UUIDs up to 30 characters.
- **Bug Fixes**: Restored missing 'w' in sequence strings and updated passphrase to default to simple lowercase words.

## Verification
- Clean build via `go build -o anbu main.go`.
- Unit tests added and passing via `go test ./...`.
- Verified CLI output for all `key-pair`, `file-crypt`, and `string` subcommands and help flags.